### PR TITLE
Fix spacing in configuration messages for ISPs

### DIFF
--- a/src/lib/isps/isp_portugal_digi.sh
+++ b/src/lib/isps/isp_portugal_digi.sh
@@ -5,7 +5,7 @@ ISP_NAME="Digi"
 
 run_isp_portugal_digi() {
     banner
-    message "Configuring $ISP_NAME ($ISP_COUNTRY):"
+    message "Configuring $ISP_NAME ($ISP_COUNTRY): "
     sleep 4
     additional_message="[INFO] $ISP_NAME ($ISP_COUNTRY): Configuration completed."
     display_main_menu  # Return to the main menu

--- a/src/lib/isps/isp_portugal_meo.sh
+++ b/src/lib/isps/isp_portugal_meo.sh
@@ -5,7 +5,7 @@ ISP_NAME="Meo"
 
 run_isp_portugal_meo() {
     banner
-    message "Configuring $ISP_NAME ($ISP_COUNTRY):"
+    message "Configuring $ISP_NAME ($ISP_COUNTRY): "
     sleep 4
     additional_message="[INFO] $ISP_NAME ($ISP_COUNTRY): Configuration completed."
     display_main_menu  # Return to the main menu

--- a/src/lib/isps/isp_portugal_nos.sh
+++ b/src/lib/isps/isp_portugal_nos.sh
@@ -5,7 +5,7 @@ ISP_NAME="Nos"
 
 run_isp_portugal_nos() {
     banner
-    message "Configuring $ISP_NAME ($ISP_COUNTRY):"
+    message "Configuring $ISP_NAME ($ISP_COUNTRY): " 
     sleep 4
     additional_message="[INFO] $ISP_NAME ($ISP_COUNTRY): Configuration completed."
     display_main_menu  # Return to the main menu

--- a/src/lib/isps/isp_portugal_vodafone.sh
+++ b/src/lib/isps/isp_portugal_vodafone.sh
@@ -6,7 +6,7 @@ ISP_NAME="Vodafone"
 run_isp_portugal_vodafone() {
     while true; do
         banner
-        echo "Configuring $ISP_NAME ($ISP_COUNTRY):"
+        echo "Configuring $ISP_NAME ($ISP_COUNTRY): "
         echo "1) Internet (Support coming soon)"
         echo "2) IPTV (Support coming soon)"
         echo "3) VOIP (Support coming soon)"


### PR DESCRIPTION
Adjust spacing in configuration messages for ISPs Digi, Meo, Vodafone, and Nos to ensure consistency and improve readability.